### PR TITLE
Fix bug in linguist.exe utility.

### DIFF
--- a/src/linguist/linguist/messagemodel.cpp
+++ b/src/linguist/linguist/messagemodel.cpp
@@ -354,6 +354,7 @@ bool DataModel::release(const QString &fileName, bool verbose, bool ignoreUnfini
     Translator tor;
     QLocale locale(m_language, m_country);
     tor.setLanguageCode(locale.name());
+    tor.setCodecName(m_codecName);
     for (DataModelIterator it(this); it.isValid(); ++it)
         tor.append(it.current()->message());
     ConversionData cd;


### PR DESCRIPTION
Purpose of this change is to fix bug in linguist.exe utility. This change enables the utility linguist.exe to apply selected codec name when it generates qm file. Without this change the utility linguist.exe always uses default codec name (ISO-8859-1) when generates qm file.