### PR TITLE
Fix (or workaround?) for excessive memory use of 'lconvert'

### DIFF
--- a/src/linguist/shared/po.cpp
+++ b/src/linguist/shared/po.cpp
@@ -420,8 +420,11 @@ bool loadPO(Translator &translator, QIODevice &dev, ConversionData &cd)
 
     // we need line based lookahead below.
     QList<QByteArray> lines;
-    while (!dev.atEnd())
-        lines.append(dev.readLine().trimmed());
+    while (!dev.atEnd()) {
+        QByteArray line = dev.readLine().trimmed();
+        line.squeeze();
+        lines.append(line);
+    }
     lines.append(QByteArray());
 
     int l = 0, lastCmtLine = -1;


### PR DESCRIPTION
See https://bugreports.qt.io/browse/QTBUG-87010 and https://github.com/Stellarium/stellarium/issues/1131